### PR TITLE
Remove `dm-env` from `requirements.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,11 @@ Then, install Haiku using pip:
 $ pip install git+https://github.com/deepmind/dm-haiku
 ```
 
-In order to run the RL `examples/` you will also need to install
-[bsuite](https://github.com/deepmind/bsuite).
+Our examples rely on additional libraries (e.g. [bsuite](https://github.com/deepmind/bsuite)). You can install the full set of additional requirements using pip:
+
+```bash
+$ pip install -r examples/requirements.txt
+```
 
 ## User manual
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Then, install Haiku using pip:
 $ pip install git+https://github.com/deepmind/dm-haiku
 ```
 
+In order to run the RL `examples/` you will also need to install
+[bsuite](https://github.com/deepmind/bsuite).
+
 ## User manual
 
 ### Writing your own modules

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,3 @@
+git+git://github.com/deepmind/bsuite.git
+tensorflow>=2.1.0
+tensorflow-datasets>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ six>=1.12.0
 dm-tree>=0.1.1
 wrapt>=1.11.1
 tabulate>=0.7.5
-dm-env>=1.2


### PR DESCRIPTION
The `dm-env` package is only used for the IMPALA example and can be removed from the core dependencies.