### PR TITLE
Allow using the hk.* version of JAX transforms outside of hk.transform

### DIFF
--- a/haiku/_src/base.py
+++ b/haiku/_src/base.py
@@ -131,6 +131,10 @@ class Frame(NamedTuple):
 current_frame = frame_stack.peek
 
 
+def inside_transform():
+  return bool(frame_stack)
+
+
 def safe_get_module_name(module) -> Text:
   # TODO(tomhennigan) Module specific code should be part of `module.py`.
   if not hasattr(module, "module_name"):

--- a/haiku/_src/stateful.py
+++ b/haiku/_src/stateful.py
@@ -174,6 +174,9 @@ def value_and_grad(fun, argnums=0, has_aux=False, holomorphic=False):
     integers, the gradient is a tuple of values with the same shapes and types
     as the corresponding arguments.
   """
+  if not base.inside_transform():
+    raise ValueError("hk.grad() should not be used outside of hk.transform(). "
+                     "Use jax.grad() instead.")
 
   @functools.wraps(fun)
   def stateful_fun(*args, **kwargs):
@@ -203,6 +206,11 @@ def thread_hk_state_in_kwargs(dec_fun):
 
   def wrapped_dec_fun(fun, *dec_args, **dec_kwargs):
     """Decorates a modified version of `fun` that passes haiku state."""
+
+    if not base.inside_transform():
+      raise ValueError(
+          "hk.{0}() should not be used outside of hk.transform. "
+          "Use jax.{0}() instead.".format(dec_fun.__name__))
 
     @functools.wraps(fun)
     def stateful_fun(*args, **kwargs):
@@ -240,6 +248,9 @@ def stateful_branch(branch_fun):
 
 def cond(pred, true_operand, true_fun, false_operand, false_fun):
   """Equivalent to `jax.lax.cond` but with Haiku state threaded in and out."""
+  if not base.inside_transform():
+    raise ValueError("hk.cond() should not be used outside of hk.transform(). "
+                     "Use jax.cond() instead.")
   state = internal_state()
   out, state = jax.lax.cond(pred,
                             true_operand=(state, true_operand),

--- a/haiku/_src/stateful_test.py
+++ b/haiku/_src/stateful_test.py
@@ -34,12 +34,22 @@ class StatefulTest(absltest.TestCase):
     g = stateful.grad(SquareModule())(x)
     np.testing.assert_allclose(g, 2 * x, rtol=1e-4)
 
+  def test_grad_no_transform(self):
+    x = jnp.array(3.)
+    with self.assertRaises(ValueError, msg='Use jax.grad() instead'):
+      stateful.grad(lambda x: x**2)(x)
+
   @test_utils.transform_and_run
   def test_value_and_grad(self):
     x = jnp.array(2.)
     y, g = stateful.value_and_grad(SquareModule())(x)
     self.assertEqual(y, x ** 2)
     np.testing.assert_allclose(g, 2 * x, rtol=1e-4)
+
+  def test_value_and_grad_no_transform(self):
+    x = jnp.array(3.)
+    with self.assertRaises(ValueError, msg='Use jax.grad() instead'):
+      stateful.value_and_grad(lambda x: x**2)(x)
 
   @test_utils.transform_and_run
   def test_grad_aux(self):
@@ -98,6 +108,11 @@ class StatefulTest(absltest.TestCase):
     y = stateful.jit(mod)(x)
     self.assertEqual(y, x ** 2)
 
+  def test_jit_no_transform(self):
+    x = jnp.array(2)
+    with self.assertRaises(ValueError, msg='Use jax.jit() instead'):
+      stateful.jit(lambda x: x**2)(x)
+
   @test_utils.transform_and_run
   def test_remat(self):
     forward, backward = [], []
@@ -133,6 +148,11 @@ class StatefulTest(absltest.TestCase):
     self.assertGreater(num_forward_remat, num_forward_no_remat)
     self.assertEqual(num_backward_remat, num_backward_no_remat)
 
+  def test_remat_no_transform(self):
+    x = jnp.array(3.)
+    with self.assertRaises(ValueError, msg='Use jax.remat() instead'):
+      stateful.remat(lambda x: x**2)(x)
+
   def test_cond(self):
     def f(x):
       mod = SquareModule()
@@ -144,6 +164,11 @@ class StatefulTest(absltest.TestCase):
       out, state = f.apply(params, state, None, x)
       self.assertEqual(state, {"square_module": {"y": y}})
       self.assertEqual(out, y)
+
+  def test_cond_no_transform(self):
+    x = jnp.array(3.)
+    with self.assertRaises(ValueError, msg='Use jax.cond() instead'):
+      stateful.cond(x == 2, x, lambda x: x**2, x, lambda x: (x + 1)**2)
 
 
 def _callback_prim(forward, backward):
@@ -182,6 +207,7 @@ class SquareModule(module.Module):
     y = x ** p
     base.set_state("y", y)
     return y
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Right now the `hk` version of the JAX transforms fail when used outside of `hk.transform` with `IndexError: deque index out of range`.
This PR changes the transforms to fall back to the Jax versions when not used with Haiku models.

Alternatively we would throw a clean error saying that users should use `jax.*` instead.