### PR TITLE
[hk] Disallow parameter creation in apply when params is None

### DIFF
--- a/haiku/_src/transform.py
+++ b/haiku/_src/transform.py
@@ -272,8 +272,8 @@ def transform_with_state(f) -> TransformedWithState:
     return ctx.collect_params(), ctx.collect_initial_state()
 
   def apply_fn(
-      params: Params,
-      state: State,
+      params: Optional[Params],
+      state: Optional[State],
       rng: Optional[Union[PRNGKey, PRNGSeed]],
       *args,
       **kwargs,
@@ -295,15 +295,15 @@ def transform_with_state(f) -> TransformedWithState:
 
 
 def check_mapping(name: str, mapping: Optional[T]) -> [T]:
+  """Cleans inputs to apply_fn, providing better errors."""
   # TODO(tomhennigan) Remove support for empty non-Mappings.
-  if mapping and not isinstance(mapping, Mapping):
+  if mapping is None:
+    # Convert None to empty dict.
+    mapping = dict()
+  if not isinstance(mapping, Mapping):
     raise TypeError(f"{name} argument does not appear valid: {mapping!r}. "
                     "For reference the parameters for apply are "
                     "`apply(params, rng, ...)`` for `hk.transform` and "
                     "`apply(params, state, rng, ...)` for "
                     "`hk.transform_with_state`.")
-  if mapping is not None:
-    return mapping
-  else:
-    # Convert None to empty dict.
-    return dict()
+  return mapping

--- a/haiku/_src/transform.py
+++ b/haiku/_src/transform.py
@@ -294,7 +294,7 @@ def transform_with_state(f) -> TransformedWithState:
   return TransformedWithState(init_fn, apply_fn)
 
 
-def check_mapping(name: str, mapping: T) -> T:
+def check_mapping(name: str, mapping: Optional[T]) -> [T]:
   # TODO(tomhennigan) Remove support for empty non-Mappings.
   if mapping and not isinstance(mapping, Mapping):
     raise TypeError(f"{name} argument does not appear valid: {mapping!r}. "
@@ -302,4 +302,8 @@ def check_mapping(name: str, mapping: T) -> T:
                     "`apply(params, rng, ...)`` for `hk.transform` and "
                     "`apply(params, state, rng, ...)` for "
                     "`hk.transform_with_state`.")
-  return mapping
+  if mapping is not None:
+    return mapping
+  else:
+    # Convert None to empty dict.
+    return dict()

--- a/haiku/_src/transform_test.py
+++ b/haiku/_src/transform_test.py
@@ -62,7 +62,7 @@ class TransformTest(parameterized.TestCase):
     self.assertEqual(params,
                      {"~": {"w1": jnp.zeros([]), "w2": jnp.ones([])}})
 
-  @parameterized.parameters(({},), ({"~": {}},))
+  @parameterized.parameters((None,), ({},), ({"~": {}},))
   def test_parameter_in_apply(self, params):
     _, apply_fn = transform.transform(
         lambda: base.get_parameter("w", [], init=jnp.zeros))


### PR DESCRIPTION
Previously, this would create new parameters:
rng = jax.random.PRNGKey(0)
module = hk.transform(lambda x: hk.Linear(10)(x), apply_rng=True)
print(module.apply(None, rng, jnp.ones((3, 2))))

Because internally it would alias to the init path.
This PR disallows this behavior for both params and state.