### PR TITLE
add missing second arg `rng` to `forward.apply` call in minimal example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ abstractions for machine learning research.
     rng = jax.random.PRNGKey(42)
     x = jnp.ones([8, 28 * 28])
     params = forward.init(rng, x)
-    logits = forward.apply(params, x)
+    logits = forward.apply(params, rng, x)
 
 Installation
 ------------


### PR DESCRIPTION
thanks to @cgarciae in https://github.com/deepmind/dm-haiku/issues/55 for the pickup!

see colab eg https://colab.research.google.com/drive/1ilWQduIWKfe1HxafUH6TZdGtzOkWbiav?usp=sharing