### PR TITLE
add delta-orthogonal initializer

### DIFF
--- a/haiku/_src/initializers.py
+++ b/haiku/_src/initializers.py
@@ -265,6 +265,51 @@ class Orthogonal(hk.initializers.Initializer):
     return jax.lax.convert_element_type(self.scale, dtype) * q_mat
 
 
+class DeltaOrthogonal(hk.initializers.Initializer):
+  """Delta-orthogonal initializer."""
+
+  def __init__(self, scale=1.0, axis=-1):
+    """Construct an initializer for delta-orthogonal matrices.
+
+    Args:
+      scale: Scale factor.
+      axis: Which axis corresponds to the "output dimension" of the tensor.
+
+    Returns:
+      An delta-orthogonally initialized parameter.
+    """
+    self.scale = scale
+    self.axis = axis
+
+  def __call__(self, shape: Sequence[int], dtype) -> jnp.ndarray:
+    if len(shape) not in [3, 4, 5]:
+      raise ValueError('Delta orthogonal initializer requires 3D,'
+                       '4D or 5D shape.')
+    w_mat = jnp.zeros(shape, dtype=dtype)
+    w_ortho = Orthogonal(self.scale, self.axis)(shape[-2:], dtype)
+    if len(shape) == 3:
+      k = shape[0]
+      return jax.ops.index_update(
+          w_mat,
+          jax.ops.index[(k - 1) // 2, ...],
+          w_ortho,
+      )
+    elif len(shape) == 4:
+      k1, k2 = shape[:2]
+      return jax.ops.index_update(
+          w_mat,
+          jax.ops.index[(k1 - 1) // 2, (k2 - 1) // 2, ...],
+          w_ortho,
+      )
+    else:
+      k1, k2, k3 = shape[:3]
+      return jax.ops.index_update(
+          w_mat,
+          jax.ops.index[(k1 - 1) // 2, (k2 - 1) // 2, (k3 - 1) // 2, ...],
+          w_ortho,
+      )
+
+
 class Identity(Initializer):
   """Initializer that generates the identity matrix.
 

--- a/haiku/initializers.py
+++ b/haiku/initializers.py
@@ -17,6 +17,7 @@
 from haiku._src.initializers import Constant
 from haiku._src.initializers import Identity
 from haiku._src.initializers import Orthogonal
+from haiku._src.initializers import DeltaOrthogonal
 from haiku._src.initializers import RandomNormal
 from haiku._src.initializers import RandomUniform
 from haiku._src.initializers import TruncatedNormal
@@ -28,6 +29,7 @@ from haiku._src.typing import Initializer
 __all__ = (
     "Constant",
     "Orthogonal",
+    "DeltaOrthogonal",
     "Identity",
     "Initializer",
     "RandomNormal",


### PR DESCRIPTION
Hi, thank you for your great work.
I really like haiku!

I want to use  [Delta-Orthogonal initialization](https://arxiv.org/abs/1806.05393) for my Reinforcement Learning repo, so I implemented it.
It's better to add it to the initializers_test.py, but it needs len(shape) in [3, 4, 5]. So I haven't added it to the test script yet.

I hope this initializer will be integrated into master so that I can use it just through pip.
Anyway, thank you for your work:)