### PR TITLE
Nit: lint SNParamsTree docstring in Haiku's spectral_norm.py

### DIFF
--- a/haiku/_src/spectral_norm.py
+++ b/haiku/_src/spectral_norm.py
@@ -178,7 +178,7 @@ class SNParamsTree(hk.Module):
         singular value of the input.
       ignore_regex: A string. Any parameter in the tree whose name matches this
         regex will not have spectral normalization applied to it. The empty
-        string means this module apply to all parameters.
+        string means this module applies to all parameters.
       name: The name of the module.
     """
     super().__init__(name=name)


### PR DESCRIPTION
I spotted a few things in docstrings while studying [Haiku Fundamentals](https://dm-haiku.readthedocs.io/en/latest/api.html#module-haiku.nets). This one applies to `SNParamsTree` (Spectral Normalization to all parameters in a tree). Hope this helps 👍