### PR TITLE
Nit: lint optimize_rng_use docstring in Haiku's random.py

### DIFF
--- a/haiku/_src/random.py
+++ b/haiku/_src/random.py
@@ -50,7 +50,7 @@ def optimize_rng_use(fun):
   ahead of time such that we only need to call :func:`jax.random.split` once.
 
   In the following example, we need three random samples for our weight
-  matricies in our 3 layer MLP. To draw these samples we use
+  matrices in our 3-layer MLP. To draw these samples we use
   :func:`~haiku.next_rng_key` which will split a new key for each sample. By
   using :func:`optimize_rng_use` Haiku will pre-allocate exactly enough RNGs for
   ``f`` to be evaluated by splitting the input key once and only once. For large


### PR DESCRIPTION
Hi @tomhennigan @inoryy I spotted a few things in docstrings while studying [Haiku Fundamentals](https://dm-haiku.readthedocs.io/en/latest/api.html#module-haiku.nets). Small stuff in [`optimize_rng_use`](https://dm-haiku.readthedocs.io/en/latest/api.html#optimize-rng-use) (Under [experimental](https://dm-haiku.readthedocs.io/en/latest/api.html#module-haiku.experimental)). Small stuff. Hope this helps 👍