### PR TITLE
Nit: change map(assert_func, items) to for loop

### DIFF
--- a/haiku/_src/base.py
+++ b/haiku/_src/base.py
@@ -509,7 +509,8 @@ class PRNGSequence(Iterator[PRNGKey]):
     if isinstance(key_or_seed, tuple):
       key, subkeys = key_or_seed
       assert_is_prng_key(key)
-      map(assert_is_prng_key, subkeys)
+      for subkey in subkeys:
+        assert_is_prng_key(subkey)
       self._key = key
       self._subkeys = collections.deque(subkeys)
     else:
@@ -550,7 +551,8 @@ class PRNGSequence(Iterator[PRNGKey]):
   def replace_internal_state(self, state: PRNGSequenceState):
     key, subkeys = state
     assert_is_prng_key(key)
-    map(assert_is_prng_key, subkeys)
+    for subkey in subkeys:
+      assert_is_prng_key(subkey)
     self._key = key
     self._subkeys = collections.deque(subkeys)
 


### PR DESCRIPTION
In python3, map function returns an iterator(not a list), and does not apply mapping function soon.
```
print(map(lambda x: x+1, [1,2,3]))  # => map object
```

In the original codes, I found the following line:
```
map(assert_is_prng_key, subkeys)
```

This line makes a map object, but does not apply function to subkeys. So, this assertion does not work.
I fixed it.