### PR TITLE
Fix collections.abc deprecation warnings

### DIFF
--- a/haiku/_src/group_norm.py
+++ b/haiku/_src/group_norm.py
@@ -109,7 +109,7 @@ class GroupNorm(hk.Module):
       self.axis = axis
     elif isinstance(axis, int):
       self.axis = (axis,)
-    elif (isinstance(axis, collections.Iterable) and
+    elif (isinstance(axis, collections.abc.Iterable) and
           all(isinstance(ax, int) for ax in axis)):
       self.axis = axis
     else:

--- a/haiku/_src/layer_norm.py
+++ b/haiku/_src/layer_norm.py
@@ -75,7 +75,7 @@ class LayerNorm(hk.Module):
       self.axis = axis
     elif isinstance(axis, int):
       self.axis = (axis,)
-    elif (isinstance(axis, collections.Iterable) and
+    elif (isinstance(axis, collections.abc.Iterable) and
           all(isinstance(ax, int) for ax in axis)):
       self.axis = tuple(axis)
     else:

--- a/haiku/_src/stateful.py
+++ b/haiku/_src/stateful.py
@@ -45,7 +45,7 @@ def internal_state(*, params=True) -> InternalState:
 
 def update_recursive(dst: MutableMapping[Any, Any], src: Mapping[Any, Any]):
   for k, v in src.items():
-    if isinstance(v, collections.Mapping):
+    if isinstance(v, collections.abc.Mapping):
       dst.setdefault(k, {})
       update_recursive(dst[k], v)
     else:

--- a/haiku/_src/utils.py
+++ b/haiku/_src/utils.py
@@ -119,7 +119,7 @@ def replicate(
 ) -> Tuple[T]:
   """Replicates entry in `element` `num_times` if needed."""
   if (isinstance(element, (str, bytes)) or
-      not isinstance(element, collections.Sequence)):
+      not isinstance(element, collections.abc.Sequence)):
     return (element,) * num_times
   elif len(element) == 1:
     return tuple(element * num_times)


### PR DESCRIPTION
These warnings are noisy starting in Python 3.9