### PR TITLE
Make MultiHeadAttention batch-agnostic

### DIFF
--- a/haiku/_src/attention.py
+++ b/haiku/_src/attention.py
@@ -70,18 +70,18 @@ class MultiHeadAttention(hk.Module):
     key_heads = self._linear_projection(key, self.key_size, "key")
     value_heads = self._linear_projection(value, self.value_size, "value")
 
-    attention_logits = jnp.einsum("bthd,bThd->bhtT", query_heads, key_heads)
+    attn_logits = jnp.einsum("...thd,...Thd->...htT", query_heads, key_heads)
     sqrt_key_size = np.sqrt(self.key_size).astype(key.dtype)
-    attention_logits = attention_logits / sqrt_key_size
+    attn_logits = attn_logits / sqrt_key_size
     if mask is not None:
-      attention_logits -= 1e10 * (1. - mask)
+      attn_logits -= 1e10 * (1. - mask)
 
-    attention_weights = jax.nn.softmax(attention_logits)
-    attention = jnp.einsum("bhtT,bThd->bthd", attention_weights, value_heads)
-    # Concatenate attention matrix of all heads into a single vector.
-    attention_vec = jnp.reshape(attention, (*query.shape[:2], -1))
+    attn_weights = jax.nn.softmax(attn_logits)
+    attn = jnp.einsum("...htT,...Thd->...thd", attn_weights, value_heads)
+    # Concatenate attn matrix of all heads into a single vector.
+    attn_vec = jnp.reshape(attn, (*query.shape[:-1], -1))
 
-    return hk.Linear(self.model_size, w_init=self.w_init)(attention_vec)
+    return hk.Linear(self.model_size, w_init=self.w_init)(attn_vec)
 
   @hk.transparent
   def _linear_projection(
@@ -91,4 +91,4 @@ class MultiHeadAttention(hk.Module):
       name: Optional[str] = None
   ) -> jnp.ndarray:
     y = hk.Linear(self.num_heads * head_size, w_init=self.w_init, name=name)(x)
-    return y.reshape((*x.shape[:2], self.num_heads, head_size))
+    return y.reshape((*x.shape[:-1], self.num_heads, head_size))

--- a/haiku/_src/attention_test.py
+++ b/haiku/_src/attention_test.py
@@ -20,20 +20,45 @@ from absl.testing import parameterized
 from haiku._src import attention
 from haiku._src import test_utils
 
-import numpy as np
+import jax.numpy as jnp
 
 
 class MultiHeadAttentionTest(parameterized.TestCase):
 
   @parameterized.named_parameters(
-      ("batch & seq len = 1", 1, 1, 3, 5, 7),
-      ("batch & seq len > 1", 2, 3, 5, 7, 11),
+      ("batch = 1 & seq len = 1", 1, 1, 3, 5, 7, 11, 13),
+      ("batch = 1 & seq len > 1", 1, 2, 3, 5, 7, 11, 13),
+      ("batch > 1 & seq len > 1", 2, 3, 5, 7, 11, 13, 17),
   )
   @test_utils.transform_and_run
-  def test_shapes(self, batch_size, seq_len, embed_size, d_key, num_heads):
-    query = key = value = np.zeros((batch_size, seq_len, embed_size))
-    mha = attention.MultiHeadAttention(d_key, num_heads, 1.0)(query, key, value)
-    self.assertEqual(mha.shape, (batch_size, seq_len, d_key * num_heads))
+  def test_shapes_batch(
+      self, batch_size, seq_len, embed_size, d_key, num_heads, d_value, d_out):
+    query = key = value = jnp.zeros((batch_size, seq_len, embed_size))
+    mha = attention.MultiHeadAttention(
+      key_size=d_key, num_heads=num_heads, value_size=d_value,
+      model_size=d_out, w_init_scale=1.0)(query, key, value)
+    self.assertEqual(mha.shape, (batch_size, seq_len, d_out))
+
+  @parameterized.named_parameters(
+      ("seq len = 1", 1, 2, 3, 5, 7, 11),
+      ("seq len > 1", 2, 3, 5, 7, 11, 13),
+  )
+  @test_utils.transform_and_run
+  def test_shapes_single(
+      self, seq_len, embed_size, d_key, num_heads, d_value, d_out):
+    query = key = value = jnp.zeros((seq_len, embed_size))
+    mha = attention.MultiHeadAttention(
+      key_size=d_key, num_heads=num_heads, value_size=d_value,
+      model_size=d_out, w_init_scale=1.0)(query, key, value)
+    self.assertEqual(mha.shape, (seq_len, d_out))
+
+  @test_utils.transform_and_run
+  def test_default_sizes(self):
+    mha = attention.MultiHeadAttention(
+      key_size=3, num_heads=5, w_init_scale=1.0)
+    self.assertEqual(mha.query_size, mha.key_size)
+    self.assertEqual(mha.value_size, mha.key_size)
+    self.assertEqual(mha.model_size, mha.key_size * mha.num_heads)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is just a minor rewriting of the existing implementation, but rewritten such that it is batch-agnostic.

This will add functionality in that it will allow for users to `vmap` and `pmap` (and in the future `xmap`) across batch axes.

Let me know what you think.