### PR TITLE
Add `pip install -U dm-haiku` to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ Then, install Haiku using pip:
 $ pip install git+https://github.com/deepmind/dm-haiku
 ```
 
+Alternatively, you can install via PyPI:
+
+```bash
+$ pip install -U dm-haiku
+```
+
 Our examples rely on additional libraries (e.g. [bsuite](https://github.com/deepmind/bsuite)). You can install the full set of additional requirements using pip:
 
 ```bash

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,10 @@ installing JAX.
 We suggest installing the latest version of Haiku by running::
 
     $ pip install git+https://github.com/deepmind/dm-haiku
+    
+Alternatively, you can install via PyPI:
+
+    $ pip install -U dm-haiku
 
 .. toctree::
    :caption: Guides

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ We suggest installing the latest version of Haiku by running::
 
     $ pip install git+https://github.com/deepmind/dm-haiku
     
-Alternatively, you can install via PyPI:
+Alternatively, you can install via PyPI::
 
     $ pip install -U dm-haiku
 


### PR DESCRIPTION
Following the addition of the PyPI badge. If this is good enough for index.rst :

`pip install -U dm-haiku`

then I can add the same to the README. LMKWYT @tomhennigan 