### PR TITLE
Use jax.numpy instead of numpy to use `at` method

### DIFF
--- a/examples/rnn/train.py
+++ b/examples/rnn/train.py
@@ -113,7 +113,7 @@ def sample(
   logits, state = hk.dynamic_unroll(core, context, core.initial_state(None))
   key, subkey = jax.random.split(rng_key)
   first_token = jax.random.categorical(subkey, logits[-1])
-  tokens = np.zeros(sample_length, dtype=np.int32)
+  tokens = jnp.zeros(sample_length, dtype=np.int32)
   tokens = tokens.at[0].set(first_token)
   initial_values = LoopValues(tokens=tokens, state=state, rng_key=key)
   values: LoopValues = lax.fori_loop(0, sample_length, body_fn, initial_values)


### PR DESCRIPTION
This fixes the error:
File "./dm-haiku/examples/rnn/train.py", line 117, in sample
    tokens = tokens.at[0].set(first_token)
AttributeError: 'numpy.ndarray' object has no attribute 'at'