### PR TITLE
Fix "output without random key" variable reference

### DIFF
--- a/docs/notebooks/basics.ipynb
+++ b/docs/notebooks/basics.ipynb
@@ -234,7 +234,7 @@
         "forward_without_rng = hk.without_apply_rng(hk.transform(_forward_fn_linear1))\n",
         "params = forward_without_rng.init(rng=rng_key, x=sample_x)\n",
         "output = forward_without_rng.apply(x=sample_x, params=params)\n",
-        "print(f'Output without random key in forward pass \\n {output_1}')"
+        "print(f'Output without random key in forward pass \\n {output}')"
       ]
     },
     {


### PR DESCRIPTION
very minor error I noticed while going through the "basics" notebook in the docs.

in the "output without random key" example, the printed reference variable is not the one just computed. the actual output is identical since the linear module is non-stochastic, but since the notebook serves primarily pedagogical purposes, I thought I would offer a correction.