### PR TITLE
Fix docs for data_structures.map

### DIFF
--- a/haiku/_src/filtering.py
+++ b/haiku/_src/filtering.py
@@ -169,9 +169,10 @@ def map(  # pylint: disable=redefined-builtin
 
   Args:
     fn: criterion to be used to map the input data.
-      The ``fn`` argument is expected to be a boolean function taking as
-      inputs the name of the module, the name of a given entry in the module
-      data bundle (e.g. parameter name) and the corresponding data.
+      The ``fn`` argument is expected to be a function taking as inputs the
+      name of the module, the name of a given entry in the module data bundle
+      (e.g. parameter name) and the corresponding data, and returning a new
+      value.
     structure: Haiku params or state data structure to be mapped.
 
   Returns:


### PR DESCRIPTION
The docs for `map` had a copy-paste error from the `filter` function docs: `map` does not take a Boolean function, it takes a transformation.