### PR TITLE
fix constant-folding of avg_pool with padding SAME

### DIFF
--- a/haiku/_src/pool.py
+++ b/haiku/_src/pool.py
@@ -140,9 +140,9 @@ def avg_pool(
   else:
     # Count the number of valid entries at each input point, then use that for
     # computing average. Assumes that any two arrays of same shape will be
-    # padded the same.
-    window_counts = lax.reduce_window(jnp.ones_like(value), *reduce_window_args)
-    assert pooled.shape == window_counts.shape
+    # padded the same. Avoid broadcasting on axis where pooling is skipped. 
+    _shape = tuple(vd if wd!=1 else 1 for (vd, wd) in zip(value.shape, window_shape))
+    window_counts = lax.reduce_window(jnp.ones(_shape), *reduce_window_args)
     return pooled / window_counts
 
 


### PR DESCRIPTION
It doesn't make a lot of sense to broadcast when there is no pooling in that dimension (batch dim for instance).

Fixes #539 

Using this PR I go from this output (current one in the issue):
```
Wall time [Initialisation]: 0.119s
2022-10-12 16:01:47.590034: E external/org_tensorflow/tensorflow/compiler/xla/service/slow_operation_alarm.cc:65] Constant folding an instruction is taking > 1s:

  reduce-window.16 (displaying the full instruction incurs a runtime overhead. Raise your logging level to 4 or above).

This isn't necessarily a bug; constant-folding is inherently a trade-off between compilation time and speed at runtime.  XLA has some guards that attempt to keep constant folding from taking too long, but fundamentally you'll always be able to come up with an input program that takes a long time.

If you'd like to file a bug, run with envvar XLA_FLAGS=--xla_dump_to=/tmp/foo and attach the results.
2022-10-12 16:02:05.867327: E external/org_tensorflow/tensorflow/compiler/xla/service/slow_operation_alarm.cc:133] The operation took 19.277362298s
Constant folding an instruction is taking > 1s:

  reduce-window.16 (displaying the full instruction incurs a runtime overhead. Raise your logging level to 4 or above).

This isn't necessarily a bug; constant-folding is inherently a trade-off between compilation time and speed at runtime.  XLA has some guards that attempt to keep constant folding from taking too long, but fundamentally you'll always be able to come up with an input program that takes a long time.

If you'd like to file a bug, run with envvar XLA_FLAGS=--xla_dump_to=/tmp/foo and attach the results.
Wall time [Compilation]: 21.8s
Wall time [Train step]: 0.00221s

```

to this 
```
Wall time [Initialisation]: 0.126s
Wall time [Compilation]: 1.43s
Wall time [Train step]: 0.00211s
```

with the same results afaik.
Let me know if this is something you'd be interested in merging :)