### PR TITLE
Update requirments.txt to match pip support

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,6 +1,6 @@
-git+git://github.com/deepmind/bsuite.git
-git+git://github.com/deepmind/optax.git
-git+git://github.com/deepmind/rlax.git
+git+https://github.com/deepmind/bsuite.git
+git+https://github.com/deepmind/optax.git
+git+https://github.com/deepmind/rlax.git
 dm-env>=1.2
 dm-tree>=0.1.1
 packaging>=20.9


### PR DESCRIPTION
using `git+git` has been [discouraged](https://pip.pypa.io/en/stable/topics/vcs-support/#git) for some time in the pip documentation, now it doesn't seem to work

```bash
$ pip install -r requirements.txt 
Collecting git+git://github.com/deepmind/bsuite.git (from -r requirements.txt (line 1))
  Cloning git://github.com/deepmind/bsuite.git to /tmp/pip-req-build-ehle11mr
  Running command git clone --filter=blob:none --quiet git://github.com/deepmind/bsuite.git /tmp/pip-req-build-ehle11mr
  fatal: unable to connect to github.com:
  github.com[0: 140.82.121.4]: errno=Connection timed out

  error: subprocess-exited-with-error
  
  × git clone --filter=blob:none --quiet git://github.com/deepmind/bsuite.git /tmp/pip-req-build-ehle11mr did not run successfully.
  │ exit code: 128
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× git clone --filter=blob:none --quiet git://github.com/deepmind/bsuite.git /tmp/pip-req-build-ehle11mr did not run successfully.
│ exit code: 128
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

changing to `git+https` fixes the issue which is also the [recommended solution](https://pip.pypa.io/en/stable/topics/vcs-support/#git)