### PR TITLE
Fix setup.py packages to avoid installing "examples" and "docs"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     long_description_content_type='text/markdown',
     author_email='haiku-dev-os@google.com',
     # Contained modules and scripts.
-    packages=find_namespace_packages(exclude=['*_test.py', 'examples']),
+    packages=find_namespace_packages(exclude=['*_test.py', 'examples*', 'docs*']),
     install_requires=_parse_requirements('requirements.txt'),
     extras_require={'jax': _parse_requirements('requirements-jax.txt')},
     tests_require=_parse_requirements('requirements-test.txt'),


### PR DESCRIPTION
This project has unintentionally included `docs` and `examples` in the packages.
As a result, running `pip install dm-haiku` will include them under `site-packages`, and you can import them like `from docs import conf`.

It is a [common pitfall](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages) when using `setuptools.find_namespace_packages()` with flat layouts, and you need to set the excludes appropriately.

#### Steps To Reproduce
1. Prepare a clean Python environment with docker, venv, etc.
`docker run --rm -it python:3.10-slim bash`
2. Install dm-haiku
`pip install dm-haiku`
3. Check under site-packages
`ls /usr/local/lib/python3.10/site-packages/ | grep docs`
4. Check if the docs can be imported
`python -c 'from docs import conf'`