### PR TITLE
Prevent module creation pyright type errors

### DIFF
--- a/haiku/_src/module.py
+++ b/haiku/_src/module.py
@@ -124,7 +124,7 @@ class ModuleMetaclass(type(Protocol)):
 
     return cls
 
-  def __call__(cls: Type[T], *args, **kwargs) -> T:  # pylint: disable=no-self-argument
+  def __call__(cls: "ModuleMetaclass", *args, **kwargs) -> Any:  # pylint: disable=no-self-argument
     # Call new such that we have an un-initialized module instance that we can
     # still reference even if there is an exception during __init__. This is
     # needed such that we can make sure the name_scope constructed in __init__


### PR DESCRIPTION
Creating any Haiku module gives type errors on the latest Pyright due to the module metaclass specification (https://github.com/microsoft/pyright/discussions/5561).  The issue is that the ideal type annotation is an intersection of `type[T]` and `ModuleMetaclass` where `T` is the return type, but Python doesn't have type intersections yet.  The authors of the code chose `type[T]`, but Pyright requires `ModuleMetaclass`.